### PR TITLE
FEATURE: Support more buttons per-category

### DIFF
--- a/javascripts/discourse/components/quick-add-tag-button.gjs
+++ b/javascripts/discourse/components/quick-add-tag-button.gjs
@@ -19,7 +19,7 @@ export default class QuickAddTagButton extends Component {
     const canEdit = this.args.topic.canEditTags;
 
     for (const settingButton in settingObj) {
-      if (settingButton.categories.split("|").includes(this.args.topic.category_id)) {
+      if (settingButton.in_categories.split("|").includes(this.args.topic.category_id)) {
         if (settingButton.auto_close_topic) {
           if (this.currentUser.moderator || this.currentUser.admin || this.currentUser.trust_level == 4) {
             return true;
@@ -35,9 +35,15 @@ export default class QuickAddTagButton extends Component {
 
   @action
   async addTag() {
+    const settingObj = settings.quick_add_tags_buttons;
     const topic = this.args.topic;
     const currentTags = topic.tags;
-    const settingTags = settings.quick_add_tags.split("|");
+    const settingTags = [];
+    for (const settingButton in settingObj) {
+      if (settingButton.in_categories.split("|").includes(topic.category_id)) {
+        settingTags = settingButton.tags.split("|");
+      }
+    }
     let newTags = currentTags;
 
     settingTags.forEach((tag) => {

--- a/javascripts/discourse/components/quick-add-tag-button.gjs
+++ b/javascripts/discourse/components/quick-add-tag-button.gjs
@@ -108,6 +108,6 @@ export default class QuickAddTagButton extends Component {
           class="btn-text"
         />
       {{/if}}
-    {{/each}}
+    {{/with}}
   </template>
 }

--- a/javascripts/discourse/components/quick-add-tag-button.gjs
+++ b/javascripts/discourse/components/quick-add-tag-button.gjs
@@ -14,7 +14,7 @@ export default class QuickAddTagButton extends Component {
   @service toasts;
   @service discovery;
 
-  @tracked category = this.discovery.category;
+  @tracked category = this.discovery;
 
   get shouldShow() {
     console.log(this.args.topic);

--- a/javascripts/discourse/components/quick-add-tag-button.gjs
+++ b/javascripts/discourse/components/quick-add-tag-button.gjs
@@ -8,7 +8,7 @@ import { service } from "@ember/service";
 import { ajax } from "discourse/lib/ajax";
 import DButton from "discourse/components/d-button";
 
-import { an, eq, or } from "truth-helpers";
+import { eq, or } from "truth-helpers";
 
 export default class QuickAddTagButton extends Component {
   @service currentUser;
@@ -103,7 +103,9 @@ export default class QuickAddTagButton extends Component {
   <template>
     {{#each settings.quick_add_tags_buttons as |setting_button|}}
       {{#if setting_button.auto_close_topic}}
+        <p>Auto close</p>
         {{#if (or this.currentUser.moderator this.currentUser.admin (eq this.currentUser.trust_level 4))}}
+          <p>Can close</p>
           <DButton
             @action={{fn (this.addTag setting_button)}}
             @icon="tag"
@@ -113,6 +115,7 @@ export default class QuickAddTagButton extends Component {
           />
         {{/if}}
       {{else if (this.args.topic.canEditTags)}}
+        <p>Can edit tags</p>
         <DButton
           @action={{fn (this.addTag setting_button)}}
           @icon="tag"

--- a/javascripts/discourse/components/quick-add-tag-button.gjs
+++ b/javascripts/discourse/components/quick-add-tag-button.gjs
@@ -17,7 +17,7 @@ export default class QuickAddTagButton extends Component {
     const topic = this.args.topic;
     console.log(topic);
     const settingObj = settings.quick_add_tags_buttons;
-    
+    console.log(settingObj);
     const canEdit = topic.canEditTags;
 
     for (const settingButton in settingObj) {

--- a/javascripts/discourse/components/quick-add-tag-button.gjs
+++ b/javascripts/discourse/components/quick-add-tag-button.gjs
@@ -14,7 +14,7 @@ export default class QuickAddTagButton extends Component {
   @service toasts;
   @service discovery;
 
-  @tracked category = this.discovery.category.id;
+  @tracked category = this.discovery.category;
 
   get shouldShow() {
     console.log(this.args.topic);
@@ -24,7 +24,7 @@ export default class QuickAddTagButton extends Component {
     const canEdit = this.args.topic.canEditTags;
 
     // for (const settingButton in settingObj) {
-    //   if (settingButton.categories.split("|").includes(this.args.topic.category_id
+    //   if (settingButton.categories.split("|").includes(this.args.topic.category_id)) {
     //   if (settings.auto_close_topic) {
     //     if (this.currentUser.moderator || this.currentUser.admin || this.currentUser.trust_level == 4) {
     //       return true;

--- a/javascripts/discourse/components/quick-add-tag-button.gjs
+++ b/javascripts/discourse/components/quick-add-tag-button.gjs
@@ -8,7 +8,7 @@ import { service } from "@ember/service";
 import { ajax } from "discourse/lib/ajax";
 import DButton from "discourse/components/d-button";
 
-import { eq, or } from "truth-helpers";
+import { eq, includes, or } from "truth-helpers";
 
 export default class QuickAddTagButton extends Component {
   @service currentUser;
@@ -102,25 +102,27 @@ export default class QuickAddTagButton extends Component {
 
   <template>
     {{#each settings.quick_add_tags_buttons as |setting_button|}}
-      {{#if setting_button.auto_close_topic}}
-        {{#if (or this.currentUser.moderator this.currentUser.admin (eq this.currentUser.trust_level 4))}}
-          <DButton
-            @action={{fn (this.addTag setting_button)}}
-            @icon="tag"
-            @label={{themePrefix "quick_add_tag_button_text"}}
-            @title={{themePrefix "quick_add_tag_button_title"}}
-            class="btn-text"
-          />
-        {{/if}}
-      {{else}}
-        {{#if (eq this.args.topic.canEditTags true)}}
-          <DButton
-            @action={{fn (this.addTag setting_button)}}
-            @icon="tag"
-            @label={{themePrefix "quick_add_tag_button_text"}}
-            @title={{themePrefix "quick_add_tag_button_title"}}
-            class="btn-text"
-          />
+      {{#if (includes setting_button.in_categories this.args.topic.category_id)}}
+        {{#if setting_button.auto_close_topic}}
+          {{#if (or this.currentUser.moderator this.currentUser.admin (eq this.currentUser.trust_level 4))}}
+            <DButton
+              @action={{fn (this.addTag setting_button)}}
+              @icon="tag"
+              @label={{themePrefix "quick_add_tag_button_text"}}
+              @title={{themePrefix "quick_add_tag_button_title"}}
+              class="btn-text"
+            />
+          {{/if}}
+        {{else}}
+          {{#if (eq this.args.topic.canEditTags true)}}
+            <DButton
+              @action={{fn (this.addTag setting_button)}}
+              @icon="tag"
+              @label={{themePrefix "quick_add_tag_button_text"}}
+              @title={{themePrefix "quick_add_tag_button_title"}}
+              class="btn-text"
+            />
+          {{/if}}
         {{/if}}
       {{/if}}
     {{/each}}

--- a/javascripts/discourse/components/quick-add-tag-button.gjs
+++ b/javascripts/discourse/components/quick-add-tag-button.gjs
@@ -20,8 +20,8 @@ export default class QuickAddTagButton extends Component {
 
     for (const settingIndex in settingObj) {
       const settingButton = settingObj[settingIndex];
-      console.log(settingButton.in_categories);
-      if (settingButton.in_categories.includes(topic.category_id)) {
+      console.log(settingButton);
+      if (settingButton.in_categories !== null && settingButton.in_categories.includes(topic.category_id)) {
         if (settingButton.auto_close_topic) {
           if (this.currentUser.moderator || this.currentUser.admin || this.currentUser.trust_level == 4) {
             return true;

--- a/javascripts/discourse/components/quick-add-tag-button.gjs
+++ b/javascripts/discourse/components/quick-add-tag-button.gjs
@@ -98,7 +98,7 @@ export default class QuickAddTagButton extends Component {
   }
 
   <template>
-    {{#with settings.quick_add_tags_buttons as |setting_button|}}
+    {{#each settings.quick_add_tags_buttons as |setting_button|}}
       {{#if this.shouldShow}}
         <DButton
           @action={{fn (this.addTag setting_button)}}
@@ -108,6 +108,6 @@ export default class QuickAddTagButton extends Component {
           class="btn-text"
         />
       {{/if}}
-    {{/with}}
+    {{/each}}
   </template>
 }

--- a/javascripts/discourse/components/quick-add-tag-button.gjs
+++ b/javascripts/discourse/components/quick-add-tag-button.gjs
@@ -18,16 +18,20 @@ export default class QuickAddTagButton extends Component {
     const cat_id = topic.category_id;
     const settingObj = settings.quick_add_tags_buttons;
     const canEdit = topic.canEditTags;
+    console.log(canEdit);
 
     for (const settingButton of settingObj) {
       if (settingButton.in_categories !== null && settingButton.in_categories.includes(cat_id)) {
         if (settingButton.auto_close_topic) {
           if (this.currentUser.moderator || this.currentUser.admin || this.currentUser.trust_level == 4) {
+            console.log("Is mod");
             this.allowedDict.cat_id = true;
           } else {
+            console.log("Not mod");
             this.allowedDict.cat_id = false;
           }
         } else {
+          console.log("Not auto close");
           this.allowedDict.cat_id = canEdit;
         }
       }

--- a/javascripts/discourse/components/quick-add-tag-button.gjs
+++ b/javascripts/discourse/components/quick-add-tag-button.gjs
@@ -15,7 +15,6 @@ export default class QuickAddTagButton extends Component {
 
   get shouldShow() {
     const topic = this.args.topic;
-    console.log(topic);
     const settingObj = settings.quick_add_tags_buttons;
     console.log(settingObj);
     const canEdit = topic.canEditTags;

--- a/javascripts/discourse/components/quick-add-tag-button.gjs
+++ b/javascripts/discourse/components/quick-add-tag-button.gjs
@@ -20,6 +20,8 @@ export default class QuickAddTagButton extends Component {
 
     for (const settingIndex in settingObj) {
       const settingButton = settingObj[settingIndex];
+      console.log(settingObj[settingIndex]);
+      console.log(settingButton);
       if (settingButton.in_categories.includes(topic.category_id)) {
         if (settingButton.auto_close_topic) {
           if (this.currentUser.moderator || this.currentUser.admin || this.currentUser.trust_level == 4) {

--- a/javascripts/discourse/components/quick-add-tag-button.gjs
+++ b/javascripts/discourse/components/quick-add-tag-button.gjs
@@ -46,7 +46,7 @@ export default class QuickAddTagButton extends Component {
     const settingObj = settings.quick_add_tags_buttons;
     const topic = this.args.topic;
     const currentTags = topic.tags;
-    const settingTags = [];
+    let settingTags = [];
     for (const settingButton of settingObj) {
       if (settingButton.in_categories.includes(topic.category_id)) {
         settingTags = settingButton.tags;

--- a/javascripts/discourse/components/quick-add-tag-button.gjs
+++ b/javascripts/discourse/components/quick-add-tag-button.gjs
@@ -1,6 +1,7 @@
 import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
 
+import { fn } from "@ember/helper"
 import { action } from "@ember/object";
 import { service } from "@ember/service";
 

--- a/javascripts/discourse/components/quick-add-tag-button.gjs
+++ b/javascripts/discourse/components/quick-add-tag-button.gjs
@@ -39,7 +39,7 @@ export default class QuickAddTagButton extends Component {
       }
     }
     console.log(this.allowedDict);
-    return this.allowedDict.find(id_bool => id_bool == cat_id);
+    return true; // this.allowedDict.find(id_bool => id_bool == cat_id);
   }
 
   @action

--- a/javascripts/discourse/components/quick-add-tag-button.gjs
+++ b/javascripts/discourse/components/quick-add-tag-button.gjs
@@ -13,9 +13,17 @@ export default class QuickAddTagButton extends Component {
   @service toasts;
   @service discovery;
 
+  // @tracked category = this.discovery.category.id;
+
+  constructor() {
+    super(...arguments);
+    async function cat() {
+      await console.log(this.discovery.category.id);
+    }
+  }
+
   get shouldShow() {
     const settingObj = settings.quick_add_tags_buttons;
-    console.log(this.discovery.category.id);
     
     const canEdit = this.args.topic.canEditTags;
     if (settings.auto_close_topic) {

--- a/javascripts/discourse/components/quick-add-tag-button.gjs
+++ b/javascripts/discourse/components/quick-add-tag-button.gjs
@@ -13,28 +13,27 @@ export default class QuickAddTagButton extends Component {
   @service toasts;
   @service discovery;
 
-  // @tracked category = this.discovery.category.id;
-
-  constructor() {
-    super(...arguments);
-    async function cat() {
-      await console.log(this.discovery.category.id);
-    }
-  }
+  @tracked category = this.discovery.category.id;
 
   get shouldShow() {
+    console.log(this.args.topic);
+    console.log(this.category);
     const settingObj = settings.quick_add_tags_buttons;
     
     const canEdit = this.args.topic.canEditTags;
-    if (settings.auto_close_topic) {
-      if (this.currentUser.moderator || this.currentUser.admin || this.currentUser.trust_level == 4) {
-        return true;
-      } else {
-        return false;
-      }
-    } else {
-      return canEdit;
-    }
+
+    // for (const settingButton in settingObj) {
+    //   if (settingButton.categories.split("|").includes(this.args.topic.category_id
+    //   if (settings.auto_close_topic) {
+    //     if (this.currentUser.moderator || this.currentUser.admin || this.currentUser.trust_level == 4) {
+    //       return true;
+    //     } else {
+    //       return false;
+    //     }
+    //   } else {
+    //     return canEdit;
+    //   }
+    // }
   }
 
   @action

--- a/javascripts/discourse/components/quick-add-tag-button.gjs
+++ b/javascripts/discourse/components/quick-add-tag-button.gjs
@@ -32,7 +32,7 @@ export default class QuickAddTagButton extends Component {
         }
       }
     }
-
+    console.log(this.allowedDict);
     return this.allowedDict.cat_id;
   }
 

--- a/javascripts/discourse/components/quick-add-tag-button.gjs
+++ b/javascripts/discourse/components/quick-add-tag-button.gjs
@@ -20,8 +20,7 @@ export default class QuickAddTagButton extends Component {
 
     for (const settingIndex in settingObj) {
       const settingButton = settingObj[settingIndex];
-      console.log(settingObj[settingIndex]);
-      console.log(settingButton);
+      console.log(settingButton.in_categories);
       if (settingButton.in_categories.includes(topic.category_id)) {
         if (settingButton.auto_close_topic) {
           if (this.currentUser.moderator || this.currentUser.admin || this.currentUser.trust_level == 4) {

--- a/javascripts/discourse/components/quick-add-tag-button.gjs
+++ b/javascripts/discourse/components/quick-add-tag-button.gjs
@@ -34,6 +34,7 @@ export default class QuickAddTagButton extends Component {
     //     return canEdit;
     //   }
     // }
+    return true;
   }
 
   @action

--- a/javascripts/discourse/components/quick-add-tag-button.gjs
+++ b/javascripts/discourse/components/quick-add-tag-button.gjs
@@ -79,8 +79,11 @@ export default class QuickAddTagButton extends Component {
             <DButton
               @action={{fn (this.addTag setting_button)}}
               @icon="tag"
-              @label={{themePrefix "quick_add_tag_button_text"}}
-              @title={{themePrefix "quick_add_tag_button_title"}}
+              {{! @label={{themePrefix "quick_add_tag_button_text"}} }}
+              {{! @title={{themePrefix "quick_add_tag_button_title"}} }}
+              @translatedLabel={{setting_button.button_label}}
+              @translatedTitle={{setting_button.button_title}}
+              
               class="btn-text"
             />
           {{/if}}
@@ -89,8 +92,11 @@ export default class QuickAddTagButton extends Component {
             <DButton
               @action={{fn (this.addTag setting_button)}}
               @icon="tag"
-              @label={{themePrefix "quick_add_tag_button_text"}}
-              @title={{themePrefix "quick_add_tag_button_title"}}
+              {{! @label={{themePrefix "quick_add_tag_button_text"}} }}
+              {{! @title={{themePrefix "quick_add_tag_button_title"}} }}
+              @translatedLabel={{setting_button.button_label}}
+              @translatedTitle={{setting_button.button_title}}
+
               class="btn-text"
             />
           {{/if}}

--- a/javascripts/discourse/components/quick-add-tag-button.gjs
+++ b/javascripts/discourse/components/quick-add-tag-button.gjs
@@ -12,30 +12,25 @@ import DButton from "discourse/components/d-button";
 export default class QuickAddTagButton extends Component {
   @service currentUser;
   @service toasts;
-  @service discovery;
-
-  @tracked category = this.discovery;
 
   get shouldShow() {
-    console.log(this.args.topic);
-    console.log(this.category);
     const settingObj = settings.quick_add_tags_buttons;
     
     const canEdit = this.args.topic.canEditTags;
 
-    // for (const settingButton in settingObj) {
-    //   if (settingButton.categories.split("|").includes(this.args.topic.category_id)) {
-    //   if (settings.auto_close_topic) {
-    //     if (this.currentUser.moderator || this.currentUser.admin || this.currentUser.trust_level == 4) {
-    //       return true;
-    //     } else {
-    //       return false;
-    //     }
-    //   } else {
-    //     return canEdit;
-    //   }
-    // }
-    return true;
+    for (const settingButton in settingObj) {
+      if (settingButton.categories.split("|").includes(this.args.topic.category_id)) {
+        if (settingButton.auto_close_topic) {
+          if (this.currentUser.moderator || this.currentUser.admin || this.currentUser.trust_level == 4) {
+            return true;
+          } else {
+            return false;
+          }
+        } else {
+          return canEdit;
+        }
+      }
+    }
   }
 
   @action

--- a/javascripts/discourse/components/quick-add-tag-button.gjs
+++ b/javascripts/discourse/components/quick-add-tag-button.gjs
@@ -20,7 +20,7 @@ export default class QuickAddTagButton extends Component {
     const canEdit = topic.canEditTags;
 
     for (const settingButton in settingObj) {
-      if (settingButton.in_categories.split("|").includes(topic.category_id)) {
+      if (settingButton.in_categories.includes(topic.category_id)) {
         if (settingButton.auto_close_topic) {
           if (this.currentUser.moderator || this.currentUser.admin || this.currentUser.trust_level == 4) {
             return true;
@@ -41,8 +41,8 @@ export default class QuickAddTagButton extends Component {
     const currentTags = topic.tags;
     const settingTags = [];
     for (const settingButton in settingObj) {
-      if (settingButton.in_categories.split("|").includes(topic.category_id)) {
-        settingTags = settingButton.tags.split("|");
+      if (settingButton.in_categories.includes(topic.category_id)) {
+        settingTags = settingButton.tags;
       }
     }
     let newTags = currentTags;

--- a/javascripts/discourse/components/quick-add-tag-button.gjs
+++ b/javascripts/discourse/components/quick-add-tag-button.gjs
@@ -73,7 +73,7 @@ export default class QuickAddTagButton extends Component {
   <template>
     {{! We move the logic here, so that we can check if the button should show per button in the settings, since (I don't think) we can pass arguments into getters }}
     {{#each settings.quick_add_tags_buttons as |setting_button|}}
-      {{#if (includes setting_button.in_categories this.args.topic.category_id)}}
+      {{#if (includes setting_button.in_categories @topic.category_id)}}
         {{#if setting_button.auto_close_topic}}
           {{#if (or this.currentUser.moderator this.currentUser.admin (eq this.currentUser.trust_level 4))}}
             <DButton
@@ -88,7 +88,7 @@ export default class QuickAddTagButton extends Component {
             />
           {{/if}}
         {{else}}
-          {{#if (eq this.args.topic.canEditTags true)}}
+          {{#if (eq @topic.canEditTags true)}}
             <DButton
               @action={{fn (this.addTag setting_button)}}
               @icon="tag"

--- a/javascripts/discourse/components/quick-add-tag-button.gjs
+++ b/javascripts/discourse/components/quick-add-tag-button.gjs
@@ -16,11 +16,10 @@ export default class QuickAddTagButton extends Component {
   get shouldShow() {
     const topic = this.args.topic;
     const settingObj = settings.quick_add_tags_buttons;
-    console.log(settingObj);
     const canEdit = topic.canEditTags;
 
-    for (const settingButton in settingObj) {
-      console.log(settingButton);
+    for (const settingIndex in settingObj) {
+      const settingButton = settingObj[settingIndex];
       if (settingButton.in_categories.includes(topic.category_id)) {
         if (settingButton.auto_close_topic) {
           if (this.currentUser.moderator || this.currentUser.admin || this.currentUser.trust_level == 4) {
@@ -41,7 +40,8 @@ export default class QuickAddTagButton extends Component {
     const topic = this.args.topic;
     const currentTags = topic.tags;
     const settingTags = [];
-    for (const settingButton in settingObj) {
+    for (const settingIndex in settingObj) {
+      const settingButton = settingObj[settingIndex];
       if (settingButton.in_categories.includes(topic.category_id)) {
         settingTags = settingButton.tags;
       }

--- a/javascripts/discourse/components/quick-add-tag-button.gjs
+++ b/javascripts/discourse/components/quick-add-tag-button.gjs
@@ -42,16 +42,10 @@ export default class QuickAddTagButton extends Component {
   }
 
   @action
-  async addTag() {
-    const settingObj = settings.quick_add_tags_buttons;
+  async addTag(setting_button) {
     const topic = this.args.topic;
     const currentTags = topic.tags;
-    let settingTags = [];
-    for (const settingButton of settingObj) {
-      if (settingButton.in_categories.includes(topic.category_id)) {
-        settingTags = settingButton.tags_to_add;
-      }
-    }
+    const settingTags = setting_button.tags;
 
     let newTags = currentTags;
 
@@ -62,12 +56,12 @@ export default class QuickAddTagButton extends Component {
     });
     
     try {
-      if (settings.auto_close_topic) {
+      if (setting_button.auto_close_topic) {
         await ajax(`/t/${topic.id}/timer.json`, {
           type: "POST",
           data: {
             status_type: "close",
-            time: settings.auto_close_topic_days * 24 // In hours, multiply by 24 to get days
+            time: setting_button.auto_close_topic_days * 24 // In hours, multiply by 24 to get days
           }
         });
       }
@@ -104,10 +98,10 @@ export default class QuickAddTagButton extends Component {
   }
 
   <template>
-    {{#each settings.quick_add_tags_buttons}}
+    {{#with settings.quick_add_tags_buttons as |setting_button|}}
       {{#if this.shouldShow}}
         <DButton
-          @action={{this.addTag}}
+          @action={{fn (this.addTag setting_button)}}
           @icon="tag"
           @label={{themePrefix "quick_add_tag_button_text"}}
           @title={{themePrefix "quick_add_tag_button_title"}}

--- a/javascripts/discourse/components/quick-add-tag-button.gjs
+++ b/javascripts/discourse/components/quick-add-tag-button.gjs
@@ -14,36 +14,6 @@ export default class QuickAddTagButton extends Component {
   @service currentUser;
   @service toasts;
 
-  // @tracked allowedDict = [];
-
-  // get shouldShow() {
-  //   const topic = this.args.topic;
-  //   const cat_id = topic.category_id;
-  //   const settingObj = settings.quick_add_tags_buttons;
-  //   console.log(topic);
-  //   const canEdit = topic.canEditTags !== undefined;
-  //   console.log(canEdit);
-
-  //   for (const settingButton of settingObj) {
-  //     if (settingButton.in_categories !== null && settingButton.in_categories.includes(cat_id)) {
-  //       if (settingButton.auto_close_topic) {
-  //         if (this.currentUser.moderator || this.currentUser.admin || this.currentUser.trust_level == 4) {
-  //           console.log("Is mod");
-  //           this.allowedDict.push({cat_id: true});
-  //         } else {
-  //           console.log("Not mod");
-  //           this.allowedDict.push({cat_id: false});
-  //         }
-  //       } else {
-  //         console.log("Not auto close");
-  //         this.allowedDict.push({cat_id: canEdit});
-  //       }
-  //     }
-  //   }
-  //   console.log(this.allowedDict);
-  //   return true; // this.allowedDict.find(id_bool => id_bool == cat_id);
-  // }
-
   @action
   async addTag(setting_button) {
     const topic = this.args.topic;
@@ -101,6 +71,7 @@ export default class QuickAddTagButton extends Component {
   }
 
   <template>
+    {{! We move the logic here, so that we can check if the button should show per button in the settings, since (I don't think) we can pass arguments into getters }}
     {{#each settings.quick_add_tags_buttons as |setting_button|}}
       {{#if (includes setting_button.in_categories this.args.topic.category_id)}}
         {{#if setting_button.auto_close_topic}}

--- a/javascripts/discourse/components/quick-add-tag-button.gjs
+++ b/javascripts/discourse/components/quick-add-tag-button.gjs
@@ -14,12 +14,14 @@ export default class QuickAddTagButton extends Component {
   @service toasts;
 
   get shouldShow() {
+    const topic = this.args.topic;
+    console.log(topic);
     const settingObj = settings.quick_add_tags_buttons;
     
-    const canEdit = this.args.topic.canEditTags;
+    const canEdit = topic.canEditTags;
 
     for (const settingButton in settingObj) {
-      if (settingButton.in_categories.split("|").includes(this.args.topic.category_id)) {
+      if (settingButton.in_categories.split("|").includes(topic.category_id)) {
         if (settingButton.auto_close_topic) {
           if (this.currentUser.moderator || this.currentUser.admin || this.currentUser.trust_level == 4) {
             return true;

--- a/javascripts/discourse/components/quick-add-tag-button.gjs
+++ b/javascripts/discourse/components/quick-add-tag-button.gjs
@@ -8,39 +8,41 @@ import { service } from "@ember/service";
 import { ajax } from "discourse/lib/ajax";
 import DButton from "discourse/components/d-button";
 
+import { an, eq, or } from "truth-helpers";
+
 export default class QuickAddTagButton extends Component {
   @service currentUser;
   @service toasts;
 
   @tracked allowedDict = [];
 
-  get shouldShow() {
-    const topic = this.args.topic;
-    const cat_id = topic.category_id;
-    const settingObj = settings.quick_add_tags_buttons;
-    console.log(topic);
-    const canEdit = topic.canEditTags !== undefined;
-    console.log(canEdit);
+  // get shouldShow() {
+  //   const topic = this.args.topic;
+  //   const cat_id = topic.category_id;
+  //   const settingObj = settings.quick_add_tags_buttons;
+  //   console.log(topic);
+  //   const canEdit = topic.canEditTags !== undefined;
+  //   console.log(canEdit);
 
-    for (const settingButton of settingObj) {
-      if (settingButton.in_categories !== null && settingButton.in_categories.includes(cat_id)) {
-        if (settingButton.auto_close_topic) {
-          if (this.currentUser.moderator || this.currentUser.admin || this.currentUser.trust_level == 4) {
-            console.log("Is mod");
-            this.allowedDict.push({cat_id: true});
-          } else {
-            console.log("Not mod");
-            this.allowedDict.push({cat_id: false});
-          }
-        } else {
-          console.log("Not auto close");
-          this.allowedDict.push({cat_id: canEdit});
-        }
-      }
-    }
-    console.log(this.allowedDict);
-    return true; // this.allowedDict.find(id_bool => id_bool == cat_id);
-  }
+  //   for (const settingButton of settingObj) {
+  //     if (settingButton.in_categories !== null && settingButton.in_categories.includes(cat_id)) {
+  //       if (settingButton.auto_close_topic) {
+  //         if (this.currentUser.moderator || this.currentUser.admin || this.currentUser.trust_level == 4) {
+  //           console.log("Is mod");
+  //           this.allowedDict.push({cat_id: true});
+  //         } else {
+  //           console.log("Not mod");
+  //           this.allowedDict.push({cat_id: false});
+  //         }
+  //       } else {
+  //         console.log("Not auto close");
+  //         this.allowedDict.push({cat_id: canEdit});
+  //       }
+  //     }
+  //   }
+  //   console.log(this.allowedDict);
+  //   return true; // this.allowedDict.find(id_bool => id_bool == cat_id);
+  // }
 
   @action
   async addTag(setting_button) {
@@ -100,8 +102,17 @@ export default class QuickAddTagButton extends Component {
 
   <template>
     {{#each settings.quick_add_tags_buttons as |setting_button|}}
-      {{#if this.shouldShow}}
-        {{setting_button.tags_to_add}}
+      {{#if setting_button.auto_close_topic}}
+        {{#if (or this.currentUser.moderator this.currentUser.admin (eq this.currentUser.trust_level 4))}}
+          <DButton
+            @action={{fn (this.addTag setting_button)}}
+            @icon="tag"
+            @label={{themePrefix "quick_add_tag_button_text"}}
+            @title={{themePrefix "quick_add_tag_button_title"}}
+            class="btn-text"
+          />
+        {{/if}}
+      {{else if (this.args.topic.canEditTags)}}
         <DButton
           @action={{fn (this.addTag setting_button)}}
           @icon="tag"

--- a/javascripts/discourse/components/quick-add-tag-button.gjs
+++ b/javascripts/discourse/components/quick-add-tag-button.gjs
@@ -11,9 +11,12 @@ import DButton from "discourse/components/d-button";
 export default class QuickAddTagButton extends Component {
   @service currentUser;
   @service toasts;
+  @service discovery;
 
   get shouldShow() {
-    console.log(settings.quick_add_tags_buttons);
+    const settingObj = settings.quick_add_tags_buttons;
+    console.log(this.discovery.category.id);
+    
     const canEdit = this.args.topic.canEditTags;
     if (settings.auto_close_topic) {
       if (this.currentUser.moderator || this.currentUser.admin || this.currentUser.trust_level == 4) {

--- a/javascripts/discourse/components/quick-add-tag-button.gjs
+++ b/javascripts/discourse/components/quick-add-tag-button.gjs
@@ -49,9 +49,12 @@ export default class QuickAddTagButton extends Component {
     let settingTags = [];
     for (const settingButton of settingObj) {
       if (settingButton.in_categories.includes(topic.category_id)) {
+        console.log(settingButton.tags);
         settingTags = settingButton.tags;
       }
     }
+    console.log(settingTags);
+
     let newTags = currentTags;
 
     settingTags.forEach((tag) => {

--- a/javascripts/discourse/components/quick-add-tag-button.gjs
+++ b/javascripts/discourse/components/quick-add-tag-button.gjs
@@ -102,12 +102,8 @@ export default class QuickAddTagButton extends Component {
 
   <template>
     {{#each settings.quick_add_tags_buttons as |setting_button|}}
-      <p>{{setting_button.auto_close_topic}}</p>
-      <p>{{setting_button.in_categories}}</p>
       {{#if setting_button.auto_close_topic}}
-        <p>Auto close</p>
         {{#if (or this.currentUser.moderator this.currentUser.admin (eq this.currentUser.trust_level 4))}}
-          <p>Can close</p>
           <DButton
             @action={{fn (this.addTag setting_button)}}
             @icon="tag"
@@ -117,9 +113,7 @@ export default class QuickAddTagButton extends Component {
           />
         {{/if}}
       {{else}}
-        {{this.args.topic.canEditTags}}
         {{#if (eq this.args.topic.canEditTags true)}}
-          <p>Can edit tags</p>
           <DButton
             @action={{fn (this.addTag setting_button)}}
             @icon="tag"

--- a/javascripts/discourse/components/quick-add-tag-button.gjs
+++ b/javascripts/discourse/components/quick-add-tag-button.gjs
@@ -20,6 +20,7 @@ export default class QuickAddTagButton extends Component {
     const canEdit = topic.canEditTags;
 
     for (const settingButton in settingObj) {
+      console.log(settingButton);
       if (settingButton.in_categories.includes(topic.category_id)) {
         if (settingButton.auto_close_topic) {
           if (this.currentUser.moderator || this.currentUser.admin || this.currentUser.trust_level == 4) {

--- a/javascripts/discourse/components/quick-add-tag-button.gjs
+++ b/javascripts/discourse/components/quick-add-tag-button.gjs
@@ -101,6 +101,7 @@ export default class QuickAddTagButton extends Component {
   <template>
     {{#each settings.quick_add_tags_buttons as |setting_button|}}
       {{#if this.shouldShow}}
+        {{setting_button.tags_to_add}}
         <DButton
           @action={{fn (this.addTag setting_button)}}
           @icon="tag"

--- a/javascripts/discourse/components/quick-add-tag-button.gjs
+++ b/javascripts/discourse/components/quick-add-tag-button.gjs
@@ -1,7 +1,7 @@
+/* eslint-disable */
 import Component from "@glimmer/component";
-import { tracked } from "@glimmer/tracking";
 
-import { fn } from "@ember/helper"
+import { fn } from "@ember/helper";
 import { action } from "@ember/object";
 import { service } from "@ember/service";
 
@@ -9,6 +9,7 @@ import { ajax } from "discourse/lib/ajax";
 import DButton from "discourse/components/d-button";
 
 import { eq, includes, or } from "truth-helpers";
+/* eslint-enable */
 
 export default class QuickAddTagButton extends Component {
   @service currentUser;
@@ -27,7 +28,7 @@ export default class QuickAddTagButton extends Component {
         newTags.push(tag);
       }
     });
-    
+
     try {
       if (setting_button.auto_close_topic) {
         await ajax(`/t/${topic.id}/timer.json`, {
@@ -44,6 +45,7 @@ export default class QuickAddTagButton extends Component {
           tags: newTags,
           keep_existing_draft: true
         }
+      // eslint-disable-next-line no-unused-vars
       }).then((response) => {
         this.toasts.success({
           duration: "short",
@@ -83,7 +85,7 @@ export default class QuickAddTagButton extends Component {
               {{! @title={{themePrefix "quick_add_tag_button_title"}}
               @translatedLabel={{setting_button.button_label}}
               @translatedTitle={{setting_button.button_title}}
-              
+
               class="btn-text"
             />
           {{/if}}

--- a/javascripts/discourse/components/quick-add-tag-button.gjs
+++ b/javascripts/discourse/components/quick-add-tag-button.gjs
@@ -79,8 +79,8 @@ export default class QuickAddTagButton extends Component {
             <DButton
               @action={{fn (this.addTag setting_button)}}
               @icon="tag"
-              {{! @label={{themePrefix "quick_add_tag_button_text"}} }}
-              {{! @title={{themePrefix "quick_add_tag_button_title"}} }}
+              {{! @label={{themePrefix "quick_add_tag_button_text"}}
+              {{! @title={{themePrefix "quick_add_tag_button_title"}}
               @translatedLabel={{setting_button.button_label}}
               @translatedTitle={{setting_button.button_title}}
               
@@ -92,8 +92,8 @@ export default class QuickAddTagButton extends Component {
             <DButton
               @action={{fn (this.addTag setting_button)}}
               @icon="tag"
-              {{! @label={{themePrefix "quick_add_tag_button_text"}} }}
-              {{! @title={{themePrefix "quick_add_tag_button_title"}} }}
+              {{! @label={{themePrefix "quick_add_tag_button_text"}}
+              {{! @title={{themePrefix "quick_add_tag_button_title"}}
               @translatedLabel={{setting_button.button_label}}
               @translatedTitle={{setting_button.button_title}}
 

--- a/javascripts/discourse/components/quick-add-tag-button.gjs
+++ b/javascripts/discourse/components/quick-add-tag-button.gjs
@@ -26,19 +26,19 @@ export default class QuickAddTagButton extends Component {
         if (settingButton.auto_close_topic) {
           if (this.currentUser.moderator || this.currentUser.admin || this.currentUser.trust_level == 4) {
             console.log("Is mod");
-            this.allowedDict.cat_id = true;
+            this.allowedDict[cat_id] = true;
           } else {
             console.log("Not mod");
-            this.allowedDict.cat_id = false;
+            this.allowedDict[cat_id] = false;
           }
         } else {
           console.log("Not auto close");
-          this.allowedDict.cat_id = canEdit;
+          this.allowedDict[cat_id] = canEdit;
         }
       }
     }
     console.log(this.allowedDict);
-    return this.allowedDict.cat_id;
+    return this.allowedDict[cat_id];
   }
 
   @action

--- a/javascripts/discourse/components/quick-add-tag-button.gjs
+++ b/javascripts/discourse/components/quick-add-tag-button.gjs
@@ -104,7 +104,7 @@ export default class QuickAddTagButton extends Component {
   }
 
   <template>
-    {{#each settings.quick_add_tag_buttons}}
+    {{#each settings.quick_add_tags_buttons}}
       {{#if this.shouldShow}}
         <DButton
           @action={{this.addTag}}

--- a/javascripts/discourse/components/quick-add-tag-button.gjs
+++ b/javascripts/discourse/components/quick-add-tag-button.gjs
@@ -13,6 +13,7 @@ export default class QuickAddTagButton extends Component {
   @service toasts;
 
   get shouldShow() {
+    console.log(settings.quick_add_tags_buttons);
     const canEdit = this.args.topic.canEditTags;
     if (settings.auto_close_topic) {
       if (this.currentUser.moderator || this.currentUser.admin || this.currentUser.trust_level == 4) {

--- a/javascripts/discourse/components/quick-add-tag-button.gjs
+++ b/javascripts/discourse/components/quick-add-tag-button.gjs
@@ -5,32 +5,35 @@ import { action } from "@ember/object";
 import { service } from "@ember/service";
 
 import { ajax } from "discourse/lib/ajax";
-import { timeShortcuts } from "discourse/lib/time-shortcut";
-import { inNDays } from "discourse/lib/time-utils";
 import DButton from "discourse/components/d-button";
 
 export default class QuickAddTagButton extends Component {
   @service currentUser;
   @service toasts;
 
+  @tracked allowedDict = {};
+
   get shouldShow() {
     const topic = this.args.topic;
+    const cat_id = topic.category_id;
     const settingObj = settings.quick_add_tags_buttons;
     const canEdit = topic.canEditTags;
 
     for (const settingButton of settingObj) {
-      if (settingButton.in_categories !== null && settingButton.in_categories.includes(topic.category_id)) {
+      if (settingButton.in_categories !== null && settingButton.in_categories.includes(cat_id)) {
         if (settingButton.auto_close_topic) {
           if (this.currentUser.moderator || this.currentUser.admin || this.currentUser.trust_level == 4) {
-            return true;
+            this.allowedDict.cat_id = true;
           } else {
-            return false;
+            this.allowedDict.cat_id = false;
           }
         } else {
-          return canEdit;
+          this.allowedDict.cat_id = canEdit;
         }
       }
     }
+
+    return this.allowedDict.cat_id;
   }
 
   @action

--- a/javascripts/discourse/components/quick-add-tag-button.gjs
+++ b/javascripts/discourse/components/quick-add-tag-button.gjs
@@ -15,12 +15,13 @@ export default class QuickAddTagButton extends Component {
 
   get shouldShow() {
     const topic = this.args.topic;
+    console.log(topic.category_id);
     const settingObj = settings.quick_add_tags_buttons;
     const canEdit = topic.canEditTags;
 
     for (const settingIndex in settingObj) {
+      console.log(settingIndex);
       const settingButton = settingObj[settingIndex];
-      console.log(settingButton);
       if (settingButton.in_categories !== null && settingButton.in_categories.includes(topic.category_id)) {
         if (settingButton.auto_close_topic) {
           if (this.currentUser.moderator || this.currentUser.admin || this.currentUser.trust_level == 4) {

--- a/javascripts/discourse/components/quick-add-tag-button.gjs
+++ b/javascripts/discourse/components/quick-add-tag-button.gjs
@@ -18,7 +18,7 @@ export default class QuickAddTagButton extends Component {
     const cat_id = topic.category_id;
     const settingObj = settings.quick_add_tags_buttons;
     console.log(topic);
-    const canEdit = topic.canEditTags;
+    const canEdit = topic.canEditTags !== undefined;
     console.log(canEdit);
 
     for (const settingButton of settingObj) {

--- a/javascripts/discourse/components/quick-add-tag-button.gjs
+++ b/javascripts/discourse/components/quick-add-tag-button.gjs
@@ -1,5 +1,5 @@
 import Component from "@glimmer/component";
-import { tracked } from @glimmer/tracking;
+import { tracked } from "@glimmer/tracking";
 
 import { action } from "@ember/object";
 import { service } from "@ember/service";

--- a/javascripts/discourse/components/quick-add-tag-button.gjs
+++ b/javascripts/discourse/components/quick-add-tag-button.gjs
@@ -17,6 +17,7 @@ export default class QuickAddTagButton extends Component {
     const topic = this.args.topic;
     const cat_id = topic.category_id;
     const settingObj = settings.quick_add_tags_buttons;
+    console.log(topic);
     const canEdit = topic.canEditTags;
     console.log(canEdit);
 

--- a/javascripts/discourse/components/quick-add-tag-button.gjs
+++ b/javascripts/discourse/components/quick-add-tag-button.gjs
@@ -15,13 +15,10 @@ export default class QuickAddTagButton extends Component {
 
   get shouldShow() {
     const topic = this.args.topic;
-    console.log(topic.category_id);
     const settingObj = settings.quick_add_tags_buttons;
     const canEdit = topic.canEditTags;
 
-    for (const settingIndex in settingObj) {
-      console.log(settingIndex);
-      const settingButton = settingObj[settingIndex];
+    for (const settingButton of settingObj) {
       if (settingButton.in_categories !== null && settingButton.in_categories.includes(topic.category_id)) {
         if (settingButton.auto_close_topic) {
           if (this.currentUser.moderator || this.currentUser.admin || this.currentUser.trust_level == 4) {
@@ -42,8 +39,7 @@ export default class QuickAddTagButton extends Component {
     const topic = this.args.topic;
     const currentTags = topic.tags;
     const settingTags = [];
-    for (const settingIndex in settingObj) {
-      const settingButton = settingObj[settingIndex];
+    for (const settingButton of settingObj) {
       if (settingButton.in_categories.includes(topic.category_id)) {
         settingTags = settingButton.tags;
       }

--- a/javascripts/discourse/components/quick-add-tag-button.gjs
+++ b/javascripts/discourse/components/quick-add-tag-button.gjs
@@ -49,11 +49,9 @@ export default class QuickAddTagButton extends Component {
     let settingTags = [];
     for (const settingButton of settingObj) {
       if (settingButton.in_categories.includes(topic.category_id)) {
-        console.log(settingButton.tags);
-        settingTags = settingButton.tags;
+        settingTags = settingButton.tags_to_add;
       }
     }
-    console.log(settingTags);
 
     let newTags = currentTags;
 

--- a/javascripts/discourse/components/quick-add-tag-button.gjs
+++ b/javascripts/discourse/components/quick-add-tag-button.gjs
@@ -14,7 +14,7 @@ export default class QuickAddTagButton extends Component {
   @service currentUser;
   @service toasts;
 
-  @tracked allowedDict = [];
+  // @tracked allowedDict = [];
 
   // get shouldShow() {
   //   const topic = this.args.topic;
@@ -102,6 +102,8 @@ export default class QuickAddTagButton extends Component {
 
   <template>
     {{#each settings.quick_add_tags_buttons as |setting_button|}}
+      <p>{{setting_button.auto_close_topic}}</p>
+      <p>{{setting_button.in_categories}}</p>
       {{#if setting_button.auto_close_topic}}
         <p>Auto close</p>
         {{#if (or this.currentUser.moderator this.currentUser.admin (eq this.currentUser.trust_level 4))}}

--- a/javascripts/discourse/components/quick-add-tag-button.gjs
+++ b/javascripts/discourse/components/quick-add-tag-button.gjs
@@ -1,4 +1,5 @@
 import Component from "@glimmer/component";
+import { tracked } from @glimmer/tracking;
 
 import { action } from "@ember/object";
 import { service } from "@ember/service";

--- a/javascripts/discourse/components/quick-add-tag-button.gjs
+++ b/javascripts/discourse/components/quick-add-tag-button.gjs
@@ -104,7 +104,7 @@ export default class QuickAddTagButton extends Component {
   }
 
   <template>
-    {{#each this.allowedDict}}
+    {{#each settings.quick_add_tag_buttons}}
       {{#if this.shouldShow}}
         <DButton
           @action={{this.addTag}}

--- a/javascripts/discourse/components/quick-add-tag-button.gjs
+++ b/javascripts/discourse/components/quick-add-tag-button.gjs
@@ -46,7 +46,7 @@ export default class QuickAddTagButton extends Component {
   async addTag(setting_button) {
     const topic = this.args.topic;
     const currentTags = topic.tags;
-    const settingTags = setting_button.tags;
+    const settingTags = setting_button.tags_to_add;
 
     let newTags = currentTags;
 

--- a/javascripts/discourse/components/quick-add-tag-button.gjs
+++ b/javascripts/discourse/components/quick-add-tag-button.gjs
@@ -11,7 +11,7 @@ export default class QuickAddTagButton extends Component {
   @service currentUser;
   @service toasts;
 
-  @tracked allowedDict = {};
+  @tracked allowedDict = [];
 
   get shouldShow() {
     const topic = this.args.topic;
@@ -26,19 +26,19 @@ export default class QuickAddTagButton extends Component {
         if (settingButton.auto_close_topic) {
           if (this.currentUser.moderator || this.currentUser.admin || this.currentUser.trust_level == 4) {
             console.log("Is mod");
-            this.allowedDict[cat_id] = true;
+            this.allowedDict.push({cat_id: true});
           } else {
             console.log("Not mod");
-            this.allowedDict[cat_id] = false;
+            this.allowedDict.push({cat_id: false});
           }
         } else {
           console.log("Not auto close");
-          this.allowedDict[cat_id] = canEdit;
+          this.allowedDict.push({cat_id: canEdit});
         }
       }
     }
     console.log(this.allowedDict);
-    return this.allowedDict[cat_id];
+    return this.allowedDict.find(id_bool => id_bool == cat_id);
   }
 
   @action
@@ -104,14 +104,16 @@ export default class QuickAddTagButton extends Component {
   }
 
   <template>
-    {{#if this.shouldShow}}
-      <DButton
-        @action={{this.addTag}}
-        @icon="tag"
-        @label={{themePrefix "quick_add_tag_button_text"}}
-        @title={{themePrefix "quick_add_tag_button_title"}}
-        class="btn-text"
-      />
-    {{/if}}
+    {{#each this.allowedDict}}
+      {{#if this.shouldShow}}
+        <DButton
+          @action={{this.addTag}}
+          @icon="tag"
+          @label={{themePrefix "quick_add_tag_button_text"}}
+          @title={{themePrefix "quick_add_tag_button_title"}}
+          class="btn-text"
+        />
+      {{/if}}
+    {{/each}}
   </template>
 }

--- a/javascripts/discourse/components/quick-add-tag-button.gjs
+++ b/javascripts/discourse/components/quick-add-tag-button.gjs
@@ -116,15 +116,18 @@ export default class QuickAddTagButton extends Component {
             class="btn-text"
           />
         {{/if}}
-      {{else if (this.args.topic.canEditTags)}}
-        <p>Can edit tags</p>
-        <DButton
-          @action={{fn (this.addTag setting_button)}}
-          @icon="tag"
-          @label={{themePrefix "quick_add_tag_button_text"}}
-          @title={{themePrefix "quick_add_tag_button_title"}}
-          class="btn-text"
-        />
+      {{else}}
+        {{this.args.topic.canEditTags}}
+        {{#if (eq this.args.topic.canEditTags true)}}
+          <p>Can edit tags</p>
+          <DButton
+            @action={{fn (this.addTag setting_button)}}
+            @icon="tag"
+            @label={{themePrefix "quick_add_tag_button_text"}}
+            @title={{themePrefix "quick_add_tag_button_title"}}
+            class="btn-text"
+          />
+        {{/if}}
       {{/if}}
     {{/each}}
   </template>

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -1,7 +1,7 @@
 en:
   added_tag_success_message: "Added tag!"
-  quick_add_tag_button_text: "Add tag"
-  quick_add_tag_button_title: "Add tag"
+  # quick_add_tag_button_text: "Add tag"
+  # quick_add_tag_button_title: "Add tag"
 
   theme_metadata:
     description: "Quickly add tag(s) to a topic with a button at the topic footer."

--- a/settings.yml
+++ b/settings.yml
@@ -4,10 +4,10 @@ quick_add_tags_buttons:
   schema:
     name: button
     properties:
-      tags:
+      tags_to_add:
         type: tags
         # list_type: tag
-      category:
+      in_categories:
         type: categories
         # list_type: category
       auto_close_topic:

--- a/settings.yml
+++ b/settings.yml
@@ -1,13 +1,34 @@
-quick_add_tags:
-  default: ""
-  type: list
-  list_type: tag
+quick_add_tags_buttons:
+  default: []
+  type: objects
+  schema:
+    name: button
+    properties:
+      tags_to_add:
+        type: list
+        list_type: tag
+      show_in_category:
+        type: list
+        list_type: category
+      auto_close_topic:
+        type: bool
+        default: false
+      auto_close_topic_days:
+        type: integer
+        default: 1
+        validations:
+          min: 0
 
-auto_close_topic:
-  default: false
-  type: bool
+# quick_add_tags:
+#   default: ""
+#   type: list
+#   list_type: tag
 
-auto_close_topic_days:
-  default: 1
-  type: integer
-  min: 0
+# auto_close_topic:
+#   default: false
+#   type: bool
+
+# auto_close_topic_days:
+#   default: 1
+#   type: integer
+#   min: 0

--- a/settings.yml
+++ b/settings.yml
@@ -11,7 +11,7 @@ quick_add_tags_buttons:
         type: categories
         # list_type: category
       auto_close_topic:
-        type: bool
+        type: boolean
         default: false
       auto_close_topic_days:
         type: integer

--- a/settings.yml
+++ b/settings.yml
@@ -6,10 +6,10 @@ quick_add_tags_buttons:
     properties:
       tags_to_add:
         type: list
-        list_type: tag
+        # list_type: tag
       show_in_category:
         type: list
-        list_type: category
+        # list_type: category
       auto_close_topic:
         type: bool
         default: false

--- a/settings.yml
+++ b/settings.yml
@@ -18,17 +18,9 @@ quick_add_tags_buttons:
         default: 1
         validations:
           min: 0
-
-# quick_add_tags:
-#   default: ""
-#   type: list
-#   list_type: tag
-
-# auto_close_topic:
-#   default: false
-#   type: bool
-
-# auto_close_topic_days:
-#   default: 1
-#   type: integer
-#   min: 0
+      button_label:
+        type: string
+        default: "Add tags"
+      button_title:
+        type: string
+        default: "Add tags"

--- a/settings.yml
+++ b/settings.yml
@@ -5,10 +5,10 @@ quick_add_tags_buttons:
     name: button
     properties:
       tags_to_add:
-        type: list
+        type: tags
         # list_type: tag
       show_in_category:
-        type: list
+        type: categories
         # list_type: category
       auto_close_topic:
         type: bool

--- a/settings.yml
+++ b/settings.yml
@@ -4,10 +4,10 @@ quick_add_tags_buttons:
   schema:
     name: button
     properties:
-      tags_to_add:
+      tags:
         type: tags
         # list_type: tag
-      show_in_category:
+      category:
         type: categories
         # list_type: category
       auto_close_topic:


### PR DESCRIPTION
This PR adds the functionality to add more that 1 button, and also provides the option to limit each button by category.

Furthermore, you can now change the button label and title for each button.

For example, you can have the following setup:

Button 1:
- Tags to add: Tag A, Tag B, Tag C
- In categories: ABC, DEF
- Auto close: Yes
- Close in how many days: 2
- Button label: Add A, B, C
- Button title: Add tags A, B and C

Button 2:
- Tags to add: Tag A, Tag D
- In categories: DEF, XYZ
- Auto close: No
- Button label: Add A, D
- Button title: Add tags A and D

This provides a much more flexible usage of this component.